### PR TITLE
CI: Add missing python requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material
+      - run: pip install -r requirements.txt
       - run: mkdocs build
       - name: Upload artifact
         uses: JamesIves/github-pages-deploy-action@v4

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material mkdocs-git-revision-date-localized-plugin
+      - run: pip install -r requirements.txt
       - run: mkdocs build
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@v1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs-material
+mkdocs-git-revision-date-localized-plugin


### PR DESCRIPTION
Builds for the main branch was broken because the pip package `mkdocs-git-revision-date-localized-plugin` was missing in the CI environment.

This commit moved the list of CI requirements to `requirements.txt`, so we don't have to remember updating the list on both Main and Preview CI workflows.