### PR TITLE
Fix: bird2 max_prefix example

### DIFF
--- a/docs/guides/route_filtering/inbound/max_prefix.md
+++ b/docs/guides/route_filtering/inbound/max_prefix.md
@@ -50,10 +50,10 @@ Configuration examples:
     ```
     protocol bgp neighbor_name {
       ipv4 {
-         import limit 1000 restart;
+         import limit 1000 action restart;
       }
       ipv6 {
-         import limit 500 restart;
+         import limit 500 action restart;
       }
     }
     ```


### PR DESCRIPTION
Hi there, ive noticed that the bird2 example for max_prefix produces a syntax error. Other examples on the internet ([1](https://mk16.de/blog/lab-en/),[2](https://bird.network.cz/pipermail/bird-users/2018-December/012945.html))seem to do it this way too.