### PR TITLE
route-filtering/inbound/default-route: fix codeblock and remove frr missing tag

### DIFF
--- a/docs/guides/route_filtering/inbound/default_route.md
+++ b/docs/guides/route_filtering/inbound/default_route.md
@@ -2,7 +2,6 @@
 tags:
   - Arista missing
   - Cisco IOS XR missing
-  - FRR missing
   - Huawei VRP missing
   - Mikrotik missing
   - Nokia SR OS missing

--- a/docs/guides/route_filtering/inbound/default_route.md
+++ b/docs/guides/route_filtering/inbound/default_route.md
@@ -41,7 +41,7 @@ On the other hand, if you want the full routing table, you should not accept any
     route-map prefixes-in deny 10
       match ip address prefix-list default-route-v4
       match ipv6 address prefix-list default-route-v6
-    ````
+    ```
 
 === "Cisco IOS XR"
     Build prefix lists with default route entries


### PR DESCRIPTION
Config snippet for FRRouting is equivalent to cisco ios