### PR TITLE
customer_prefix.md: fix code block

### DIFF
--- a/docs/guides/route_filtering/outbound/customer_prefix.md
+++ b/docs/guides/route_filtering/outbound/customer_prefix.md
@@ -68,7 +68,7 @@ Please make sure to filter the prefixes of your BGP customers directly on the BG
     set policy-options policy-statement MY_OUTPUT_FILTER term CUSTOMER-PREFIXES-V6 from community CUSTOMER
     set policy-options policy-statement MY_OUTPUT_FILTER term CUSTOMER-PREFIXES-V6 from route-filter ::/0 prefix-length-range /12-/48
     set policy-options policy-statement MY_OUTPUT_FILTER term CUSTOMER-PREFIXES-V6 then accept
-    
+    ```
 
 === "Cisco IOS XR"
 


### PR DESCRIPTION
Just a quick fix for [the code block](https://routing.denog.de/guides/route_filtering/outbound/customer_prefix/) because it wasn't properly closed.