### PR TITLE
Several small fixes after reviewing the content.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,12 +1,12 @@
 # Code of Conduct
 
-This CoC is based on the the [Rust projects](https://www.rust-lang.org/policies/code-of-conduct).
+This CoC is based on the [Rust projects](https://www.rust-lang.org/policies/code-of-conduct).
 
 * We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other similar characteristic.
 * Please avoid using overtly sexual aliases or other nicknames that might detract from a friendly, safe and welcoming environment for all.
 * Please be kind and courteous. There’s no need to be mean or rude.
 * Respect that people have differences of opinion and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a right answer.
 * Please keep unstructured critique to a minimum. If you have solid ideas you want to experiment with, make a fork and see how it works.
-* We will exclude you from interaction if you insult, demean or harass anyone. That is not welcome behavior. We interpret the term “harassment” as including the definition in the [Citizen Code of Conduct](https://web.archive.org/web/20221031230228/https://github.com/stumpsyn/policies/blob/master/citizen_code_of_conduct.md); if you have any lack of clarity about what might be included in that concept, please read their definition. In particular, we don’t tolerate behavior that excludes people in socially marginalized groups.
+* We will exclude you from interaction if you insult, demean or harass anyone. That is not welcome behavior. We interpret the term “harassment” as including the definition in the [Citizen Code of Conduct](https://github.com/stumpsyn/policies/blob/master/citizen_code_of_conduct.md); if you have any lack of clarity about what might be included in that concept, please read their definition. In particular, we don’t tolerate behavior that excludes people in socially marginalized groups.
 * Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member, please contact one of the chair or board members immediately. Whether you’re a regular contributor or a newcomer, we care about making this community a safe place for you and we’ve got your back.
 * Likewise any spamming, trolling, flaming, baiting or other attention-stealing behavior is not welcome.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ We have a [Code of Conduct](https://github.com/denog/routing-guide/blob/main/COD
 
 ## Deployment
 
-The main branch is deployed to [routing.denog.de](https://routing.denog.de/) the automtically.
+The main branch is deployed to [routing.denog.de](https://routing.denog.de/) the automatically.
 
 ## Development
 

--- a/docs/guides/control_plane_protection/protect_your_bgp_session.md
+++ b/docs/guides/control_plane_protection/protect_your_bgp_session.md
@@ -8,7 +8,7 @@ The idea of these measures is to protect your TCP-based BGP sessions against att
 
 ### MD5 session password
 
-The easiest countermeasure against TCP based attacks on BGP sessions is to use  MD5 protection as described in
+The easiest countermeasure against TCP based attacks on BGP sessions is to use MD5 protection as described in
 [RFC2385](https://www.rfc-editor.org/rfc/rfc2385.html).
 When implementing this, keep in mind to also implement some key (password) handling procedures (just imagine your router has to be replaced and you have to re-create all eBGP configurations).
 
@@ -118,11 +118,11 @@ Configuration examples:
         remote-address=198.51.100.1 remote-as=64496 ttl=255
     ```
 === "Juniper"
-    On Junos you configure how many hops your neighbors in a group are away:
+    On JunOS you configure how many hops your neighbors in a group are away:
     ```
     set protocols bgp group <GROUPNAME> ttl 255
     ```
-    On Junos you configure how many hops a specific neighbor in a group is away:
+    On JunOS you configure how many hops a specific neighbor in a group is away:
     ```
     set protocols bgp group <GROUPNAME> neighbor 198.51.100.1 ttl 255
     ```

--- a/docs/guides/route_filtering/inbound/as_path_length.md
+++ b/docs/guides/route_filtering/inbound/as_path_length.md
@@ -33,7 +33,7 @@ The AS PATH in the DFZ can become very long. At some point this can become an is
     exit
     ```
 
-=== "Juniper Junos"  
+=== "Juniper JunOS"
     ```
     [edit policy-options]
         as-path AS-PATH-MAX-LENGTH ".{50,}";

--- a/docs/guides/route_filtering/inbound/bogon_asn.md
+++ b/docs/guides/route_filtering/inbound/bogon_asn.md
@@ -12,18 +12,18 @@ Bogon AS are autonomous systems which are used for test or demo applications. Th
     as-path-set bogon-asns
        # RFC7607
        ios-regex '_0_',
-       # 2 to 4 byte ASN migrations
+       # RFC4893: AS_TRANS, 2 to 4 byte ASN migrations
        passes-through '23456',
-       # RFC5398
+       # RFC5398: documentation/example ASNs
        passes-through '[64496..64511]',
        passes-through '[65536..65551]',
-       # RFC6996
+       # RFC6996: private ASNs
        passes-through '[64512..65534]',
        passes-through '[4200000000..4294967294]',
-       # RFC7300
+       # RFC7300: last 16/32 bit ASN
        passes-through '65535',
        passes-through '4294967295',
-       # IANA reserved
+       # IANA reserved ASNs
        passes-through '[65552..131071]'
     end-set
 
@@ -39,15 +39,15 @@ Bogon AS are autonomous systems which are used for test or demo applications. Th
 === "Bird2"
     ```
     define BOGON_ASNS = [
-      0,                      # RFC 7607
-      23456,                  # RFC 4893 AS_TRANS
-      64496..64511,           # RFC 5398 and documentation/example ASNs
-      64512..65534,           # RFC 6996 Private ASNs
-      65535,                  # RFC 7300 Last 16 bit ASN
-      65536..65551,           # RFC 5398 and documentation/example ASNs
-      65552..131071,          # RFC IANA reserved ASNs
-      4200000000..4294967294, # RFC 6996 Private ASNs
-      4294967295              # RFC 7300 Last 32 bit ASN
+      0,                      # RFC7607
+      23456,                  # RFC4893 AS_TRANS, 2 to 4 byte ASN migrations
+      64496..64511,           # RFC5398 documentation/example ASNs
+      64512..65534,           # RFC6996 private ASNs
+      65535,                  # RFC7300 last 16 bit ASN
+      65536..65551,           # RFC5398 documentation/example ASNs
+      65552..131071,          # IANA reserved ASNs
+      4200000000..4294967294, # RFC6996 private ASNs
+      4294967295              # RFC7300 last 32 bit ASN
     ];
     function reject_bogon_asns()
     int set bogon_asns;
@@ -66,7 +66,7 @@ Bogon AS are autonomous systems which are used for test or demo applications. Th
     }
     ```
 
-=== "Juniper"
+=== "Juniper JunOS"
     ```
     set policy-options as-path-group CYMRU-BOGON-ASN as-path zero ".* 0 .*"
     set policy-options as-path-group CYMRU-BOGON-ASN as-path as_trans ".* 23456 .*"

--- a/docs/guides/route_filtering/inbound/bogon_prefixes.md
+++ b/docs/guides/route_filtering/inbound/bogon_prefixes.md
@@ -24,9 +24,9 @@ In IPv6, there is a [similar list at IANA](http://www.iana.org/assignments/ipv6-
 === "Cisco IOS / FRRouting"
     For IPv4, you can simply add all unwanted prefixes to the list we defined in the previous section:
     ```
-    ip prefix-list ipv4-unwanted permit 192.168.0.0/16 le 32
-    ip prefix-list ipv4-unwanted permit 172.16.0.0/12 le 32
     ip prefix-list ipv4-unwanted permit 10.0.0.0/8 le 32
+    ip prefix-list ipv4-unwanted permit 172.16.0.0/12 le 32
+    ip prefix-list ipv4-unwanted permit 192.168.0.0/16 le 32
     ...
     ```
 
@@ -34,40 +34,40 @@ In IPv6, there is a [similar list at IANA](http://www.iana.org/assignments/ipv6-
     For IPv4, you can simply add all unwanted prefixes to the list:
     ```
     prefix-set bogon-ipv4
-      # RFC 1122 'this' Network
+      # RFC1122 'this' Network
       0.0.0.0/8 le 32,
-      # RFC 1918 Private
+      # RFC1918 Private
       10.0.0.0/8 le 32,
-      # RFC 6598 Carrier grade nat space
+      # RFC6598 Carrier grade nat space
       100.64.0.0/10 le 32,
-      # RFC 1122 Loopback
+      # RFC1122 Loopback
       127.0.0.0/8 le 32,
-      # RFC 3927 Link Local
+      # RFC3927 Link Local
       169.254.0.0/16 le 32,
-      # RFC 1918 Private
+      # RFC1918 Private
       172.16.0.0/12 le 32,
-      # RFC 6890 Protocol Assignments
+      # RFC6890 Protocol Assignments
       192.0.0.0/24 le 32,
-      # RFC 5737 Documentation TEST-NET-1
+      # RFC5737 Documentation TEST-NET-1
       192.0.2.0/24 le 32,
-      # RFC 7526 6to4 anycast relay
+      # RFC7526 6to4 anycast relay
       192.88.99.0/24 le 32,
-      # RFC 1918 Private
+      # RFC1918 Private
       192.168.0.0/16 le 32,
-      # RFC 2544 Benchmarking
+      # RFC2544 Benchmarking
       198.18.0.0/15 le 32,
-      # RFC 5737 Documentation TEST-NET-2
+      # RFC5737 Documentation TEST-NET-2
       198.51.100.0/24 le 32,
-      # RFC 5737 Documentation TEST-NET-3
+      # RFC5737 Documentation TEST-NET-3
       203.0.113.0/24 le 32,
-      # RFC 5771 Multicast
+      # RFC5771 Multicast
       224.0.0.0/4 le 32,
-      # RFC 1112 Reserved
+      # RFC1112 Reserved
       240.0.0.0/4 le 32
     end-set
     
     prefix-set bogon-ipv6
-      #IETF reserved
+      # IETF reserved
       ::/8 le 128,
       # RFC6666 Discard-Only Address Block
       100::/64 le 128,
@@ -104,42 +104,42 @@ In IPv6, there is a [similar list at IANA](http://www.iana.org/assignments/ipv6-
     You can add this to your existing filter or you can create a sub-filter for better readability:
     ```
     /routing filter
-    add action=reject chain=ipv4-unwanted prefix=192.168.0.0/16 prefix-length=16-32
-    add action=reject chain=ipv4-unwanted prefix=172.16.0.0/12 prefix-length=12-32
     add action=reject chain=ipv4-unwanted prefix=10.0.0.0/8 prefix-length=8-32
+    add action=reject chain=ipv4-unwanted prefix=172.16.0.0/12 prefix-length=12-32
+    add action=reject chain=ipv4-unwanted prefix=192.168.0.0/16 prefix-length=16-32
     ...
     ```
 
 === "Bird2"
     ```
     define BOGON_PREFIXES4 = [
-      0.0.0.0/8+,         # RFC 1122 'this' Network
-      10.0.0.0/8+,        # RFC 1918 Private
-      100.64.0.0/10+,     # RFC 6598 Carrier grade nat space
-      127.0.0.0/8+,       # RFC 1122 Loopback
-      169.254.0.0/16+,    # RFC 3927 Link Local
-      172.16.0.0/12+,     # RFC 1918 Private
-      192.0.2.0/24+,      # RFC 5737 Documentation TEST-NET-1
-      192.168.0.0/16+,    # RFC 1918 Private
-      198.18.0.0/15+,     # RFC 2544 Benchmarking
-      198.51.100.0/24+,   # RFC 5737 Documentation TEST-NET-2
-      203.0.113.0/24+,    # RFC 5737 Documentation TEST-NET-3
-      224.0.0.0/4+,       # RFC 5771 Multicast
-      240.0.0.0/4+        # RFC 1112 Reserved
+      0.0.0.0/8+,         # RFC1122 'this' Network
+      10.0.0.0/8+,        # RFC1918 Private
+      100.64.0.0/10+,     # RFC6598 Carrier grade nat space
+      127.0.0.0/8+,       # RFC1122 Loopback
+      169.254.0.0/16+,    # RFC3927 Link Local
+      172.16.0.0/12+,     # RFC1918 Private
+      192.0.2.0/24+,      # RFC5737 Documentation TEST-NET-1
+      192.168.0.0/16+,    # RFC1918 Private
+      198.18.0.0/15+,     # RFC2544 Benchmarking
+      198.51.100.0/24+,   # RFC5737 Documentation TEST-NET-2
+      203.0.113.0/24+,    # RFC5737 Documentation TEST-NET-3
+      224.0.0.0/4+,       # RFC5771 Multicast
+      240.0.0.0/4+        # RFC1112 Reserved
     ];
     define BOGON_PREFIXES6 = [
-        ::/8+,           # RFC4291 Loopback and more
-        0100::/64+,      # RFC6666 Discard-Only Address Block
-        2001:2::/48+,    # RFC5180 Benchmarking
-        2001:10::/28+    # RFC4843 ORCHID
-        2001:db8::/32+,  # RFC7450 Documentation
-        3ffe::/16+,      # RFC3701 old 6bone
-        3fff::/20+,      # RFC9637 Documentation
-        5f00::/16+,      # RFC9602 SRv6 SIDs
-        fc00::/7+,       # RFC4193,RFC8190 Unique-Local
-        fe80::/10+       # RFC4291 Link-Local Unicast
-        fec0::/10+       # RFC3879 old Site-Local Unicast
-        ff00::/8+        # RFC4291 Multicast
+        ::/8+,            # RFC4291 Loopback and more
+        0100::/64+,       # RFC6666 Discard-Only Address Block
+        2001:2::/48+,     # RFC5180 Benchmarking
+        2001:10::/28+     # RFC4843 ORCHID
+        2001:db8::/32+,   # RFC7450 Documentation
+        3ffe::/16+,       # RFC3701 old 6bone
+        3fff::/20+,       # RFC9637 Documentation
+        5f00::/16+,       # RFC9602 SRv6 SIDs
+        fc00::/7+,        # RFC4193,RFC8190 Unique-Local
+        fe80::/10+        # RFC4291 Link-Local Unicast
+        fec0::/10+        # RFC3879 old Site-Local Unicast
+        ff00::/8+         # RFC4291 Multicast
     ];
     function reject_bogon_prefixes4()
     prefix set bogon_prefixes4;
@@ -173,7 +173,7 @@ In IPv6, there is a [similar list at IANA](http://www.iana.org/assignments/ipv6-
     }
     ```
     
-=== "Juniper"
+=== "Juniper JunOS"
     For IPv4 as an own policy:
     ```
     set policy-options policy-statement IPV4-BOGONS term IANA-LOCAL-IDENTIFICATION from route-filter 0.0.0.0/8 orlonger
@@ -202,6 +202,7 @@ In IPv6, there is a [similar list at IANA](http://www.iana.org/assignments/ipv6-
     set policy-options policy-statement IPV4-BOGONS term IANA-MULTICAST then accept
     set policy-options policy-statement IPV4-BOGONS term IANA-CLASS-E from route-filter 240.0.0.0/4 orlonger
     set policy-options policy-statement IPV4-BOGONS term IANA-CLASS-E then accept
+    set policy-options policy-statement IPV4-BOGONS term REJECT from route-filter 0.0.0.0/0 orlonger
     set policy-options policy-statement IPV4-BOGONS term REJECT then reject
     ```
 
@@ -212,15 +213,13 @@ In IPv6, there is a [similar list at IANA](http://www.iana.org/assignments/ipv6-
     set policy-options policy-statement IPV6-BOGONS term MULTICAST from route-filter fe00::/9 orlonger
     set policy-options policy-statement IPV6-BOGONS term MULTICAST from route-filter ff00::/8 orlonger
     set policy-options policy-statement IPV6-BOGONS term MULTICAST then accept
-    set policy-options policy-statement IPV6-BOGONS term DOCUMENTATION-PREFIX from route-filter 2002:db8::/32 orlonger
     set policy-options policy-statement IPV6-BOGONS term DOCUMENTATION-PREFIX from route-filter 2001:db8::/32 orlonger
+    set policy-options policy-statement IPV6-BOGONS term DOCUMENTATION-PREFIX from route-filter 3fff::/20 orlonger
     set policy-options policy-statement IPV6-BOGONS term DOCUMENTATION-PREFIX then accept
     set policy-options policy-statement IPV6-BOGONS term 6BONE from route-filter 3ffe::/16 orlonger
     set policy-options policy-statement IPV6-BOGONS term 6BONE then accept
-    set policy-options policy-statement IPV6-BOGONS term TEREDO-ACCEPT from route-filter 2002::/32 exact
     set policy-options policy-statement IPV6-BOGONS term TEREDO-ACCEPT from route-filter 2001::/32 exact
     set policy-options policy-statement IPV6-BOGONS term TEREDO-ACCEPT then next policy
-    set policy-options policy-statement IPV6-BOGONS term TEREDO-REJECT from route-filter 2002::/32 longer
     set policy-options policy-statement IPV6-BOGONS term TEREDO-REJECT from route-filter 2001::/32 longer
     set policy-options policy-statement IPV6-BOGONS term TEREDO-REJECT then accept
     set policy-options policy-statement IPV6-BOGONS term 6TO4-ACCEPT from route-filter 2002::/16 exact
@@ -233,6 +232,7 @@ In IPv6, there is a [similar list at IANA](http://www.iana.org/assignments/ipv6-
 
     Usage within another policy (nested policies):
     ```
+    set policy-options policy-statement MY_INPUT_POLICY term BOGONS-V4 from family inet
     set policy-options policy-statement MY_INPUT_POLICY term BOGONS-V4 from policy IPV4-BOGONS
     set policy-options policy-statement MY_INPUT_POLICY term BOGONS-V4 then trace
     set policy-options policy-statement MY_INPUT_POLICY term BOGONS-V4 then reject

--- a/docs/guides/route_filtering/inbound/default_route.md
+++ b/docs/guides/route_filtering/inbound/default_route.md
@@ -122,8 +122,9 @@ On the other hand, if you want the full routing table, you should not accept any
     }
     ```
 
-=== "Juniper"
+=== "Juniper JunOS"
      ```
+     set policy-options policy-statement MY_INPUT_FILTER term DEFAULT-ROUTE from family inet
      set policy-options policy-statement MY_INPUT_FILTER term DEFAULT-ROUTE from route-filter 0.0.0.0/0 exact
      set policy-options policy-statement MY_INPUT_FILTER term DEFAULT-ROUTE then trace
      set policy-options policy-statement MY_INPUT_FILTER term DEFAULT-ROUTE then reject

--- a/docs/guides/route_filtering/inbound/max_prefix.md
+++ b/docs/guides/route_filtering/inbound/max_prefix.md
@@ -69,7 +69,7 @@ Configuration examples:
             exit
     ```
 
-=== "Juniper"
+=== "Juniper JunOS"
     ```
     set protocols bgp group MY_NEIGHBOR_GROUP 198.51.100.1 family inet unicast accepted-prefix-limit maximum 10 drop-excess
     set protocols bgp group MY_NEIGHBOR_GROUP 2001:db8::1 family inet6 unicast accepted-prefix-limit maximum 5 drop-excess

--- a/docs/guides/route_filtering/inbound/own_bgp_communities.md
+++ b/docs/guides/route_filtering/inbound/own_bgp_communities.md
@@ -37,7 +37,7 @@ See https://routing.denog.de/guides/route_filtering/outbound/well_known_communit
 ## Configuration Examples
 
 === "Cisco IOS XR"
-    Using an *my-own* communitys-set you can add  more communities to it that you want. Since these are your own complete communities, you can work with wildcards.
+    Using an *my-own* communitys-set you can add more communities to it that you want. Since these are your own complete communities, you can work with wildcards.
     ```
     community-set my-own-communities
       <YOUR OWN AS NUMBER>:*
@@ -68,7 +68,7 @@ See https://routing.denog.de/guides/route_filtering/outbound/well_known_communit
       endif
     end-policy
     ```
-=== "Juniper"
+=== "Juniper JunOS"
 Standard community
     ```
     set policy-options community CUSTOMER members 65534:100
@@ -77,6 +77,6 @@ Standard community
 Large community
     ```
     set policy-options community CUSTOMER members large:4200000001:0:1002
-    set policy-options community TEST members large:205806:0:100
+    set policy-options community TEST members large:64500:0:100
     set policy-options community UPSTREAM members large:65534:0:200
     ```

--- a/docs/guides/route_filtering/inbound/own_prefix.md
+++ b/docs/guides/route_filtering/inbound/own_prefix.md
@@ -10,7 +10,7 @@ Your own networks should be stored in lists and then used in policy for external
 
 ## Configuration
 === "Cisco IOS XR"
-    Your own prefixes to the list:
+    Add your own prefixes to the list:
     ```
     prefix-set my-own-network-ipv4
       <Please enter your own prefix with netmask here> le 32,
@@ -18,8 +18,8 @@ Your own networks should be stored in lists and then used in policy for external
     end-set
     
     prefix-set my-own-network-ipv6
-      <Please enter your own prefix with netmask here> le le 128,
-      <Please enter your own prefix with netmask here> le le 128
+      <Please enter your own prefix with netmask here> le 128,
+      <Please enter your own prefix with netmask here> le 128
     end-set
     ```
 
@@ -43,7 +43,7 @@ Your own networks should be stored in lists and then used in policy for external
     ```
     The policy should be part of a central policy for the external BGP peer.
 
-=== "Juniper"
+=== "Juniper JunOS"
     Create prefix list containtaing your own prefixes:
     ```
     set policy-options prefix-list MY-PREFIXES-V4 <PLEASE INSERT YOUR PREFIX HERE>
@@ -54,6 +54,7 @@ Your own networks should be stored in lists and then used in policy for external
     Add it to your Import Policy:
 
     ```
+    set policy-options policy-statement MY_INPUT_FILTER term FILTER-OWN-PREFIXES-V4 from family inet
     set policy-options policy-statement MY_INPUT_FILTER term FILTER-OWN-PREFIXES-V4 from prefix-list-filter MY-PREFIXES-V4 orlonger
     set policy-options policy-statement MY_INPUT_FILTER term FILTER-OWN-PREFIXES-V4 then trace
     set policy-options policy-statement MY_INPUT_FILTER term FILTER-OWN-PREFIXES-V4 then reject

--- a/docs/guides/route_filtering/inbound/peering_lan.md
+++ b/docs/guides/route_filtering/inbound/peering_lan.md
@@ -10,7 +10,7 @@ So it is strongly recommended that you block BGP announcements of all IXP LANs y
 connected to.
 
 If you are connected to many IXPs, you might want to automate this.
-[PeeringDB](https://peeringdb.com) has a list of all IXP Lans, you need some software to extract this
+[PeeringDB](https://peeringdb.com) has a list of all IXP Lans. You need some software to extract this
 and convert it to your router configuration.
 
 ## Configuration Examples

--- a/docs/guides/route_filtering/inbound/prefix_length.md
+++ b/docs/guides/route_filtering/inbound/prefix_length.md
@@ -10,7 +10,7 @@ Normally (there are exceptions), prefixes are announced in certain minimum and m
 Configuration examples:
 
 === "Cisco IOS"
-    Using an *unwanted* prefix-list you can add  more prefixes to it that you not want. This shortens your configuration but might also decrease readability.
+    Using an *unwanted* prefix-list you can add more prefixes to it that you not want. This shortens your configuration but might also decrease readability.
     ```
     ip prefix-list ipv4-unwanted permit 0.0.0.0/0 ge 25 le 32
     ip prefix-list ipv4-unwanted permit 0.0.0.0/0 ge 1 le 7
@@ -32,7 +32,7 @@ Configuration examples:
     ```
 
 === "Cisco IOS XR"
-    Use an *permitted* list and you can still customize the range. Please note that these areas are common on the public internet.
+    Use an *permitted* list and you can still customize the range. Please note that these areas are common on the public Internet.
     ```
     # Define permitted IP prefixes
     prefix-set permitted-prefix-length-v4
@@ -139,8 +139,9 @@ Configuration examples:
     commit
     ```
 
-=== "Juniper"
+=== "Juniper JunOS"
     ```
+    set policy-options policy-statement MY_INPUT_FILTER term MAX-LEN-PREFIXES-V4 from family inet
     set policy-options policy-statement MY_INPUT_FILTER term MAX-LEN-PREFIXES-V4 from route-filter 0.0.0.0/0 prefix-length-range /25-/32
     set policy-options policy-statement MY_INPUT_FILTER term MAX-LEN-PREFIXES-V4 then trace
     set policy-options policy-statement MY_INPUT_FILTER term MAX-LEN-PREFIXES-V4 then reject

--- a/docs/guides/route_filtering/inbound/require_policy.md
+++ b/docs/guides/route_filtering/inbound/require_policy.md
@@ -4,7 +4,7 @@ Some routers accept configuration commands as you type them in line by line. At 
 
 Now, if you setup a BGP session to a neighbor and the router accepts it line by line, the session will be established once "enough" configuration is entered, independent if you have completed the configuration or not.
 
-So imagine you enter the neigbhbors AS number and IP address and then you go for a coffee. This might be enough to establish a session. Without any filtering, you now will receive everything from that neighbor and also announce every valid prefix in your own BGP tables. Most of the times, this is not what you want.
+So imagine you enter the neighbors AS number and IP address and then you go for a coffee. This might be enough to establish a session. Without any filtering, you now will receive everything from that neighbor and also announce every valid prefix in your own BGP tables. Most of the times, this is not what you want.
 
 [RFC8212](https://www.rfc-editor.org/rfc/rfc8212.html)
 requires that you *must* configure an import and an export policy (= some filtering) on any external BGP session, otherwise the session will not be initiated or accepted.

--- a/docs/guides/route_filtering/outbound/customer_prefix.md
+++ b/docs/guides/route_filtering/outbound/customer_prefix.md
@@ -18,6 +18,7 @@ Please make sure to filter the prefixes of your BGP customers directly on the BG
     set policy-options prefix-list CUSTOMER-PREFIXES-V4 <PLEASE INSERT CUSTOMER PREFIX HERE>
     set policy-options prefix-list CUSTOMER-PREFIXES-V6 <PLEASE INSERT CUSTOMER PREFIX HERE>
     
+    set policy-options policy-statement MY_OUTPUT_FILTER term CUSTOMER-PREFIXES-V4 from family inet
     set policy-options policy-statement MY_OUTPUT_FILTER term CUSTOMER-PREFIXES-V4 from prefix-list CUSTOMER-PREFIXES-V4
     set policy-options policy-statement MY_OUTPUT_FILTER term CUSTOMER-PREFIXES-V4 then accept
     set policy-options policy-statement MY_OUTPUT_FILTER term CUSTOMER-PREFIXES-V6 from family inet6
@@ -37,6 +38,7 @@ Please make sure to filter the prefixes of your BGP customers directly on the BG
     
     set policy-options policy-statement CUSTOMER-BLAH-IN term TAG-PREFIXES then community add CUSTOMER
     set policy-options policy-statement CUSTOMER-BLAH-IN term TAG-PREFIXES then next term
+    set policy-options policy-statement CUSTOMER-BLAH-IN term CUSTOMER-ROUTES-V4 from family inet
     set policy-options policy-statement CUSTOMER-BLAH-IN term CUSTOMER-ROUTES-V4 from prefix-list CUSTOMER-BLAH-V4
     set policy-options policy-statement CUSTOMER-BLAH-IN term CUSTOMER-ROUTES-V4 then accept
     set policy-options policy-statement CUSTOMER-BLAH-IN term CUSTOMER-ROUTES-V6 from family inet6
@@ -61,6 +63,7 @@ Please make sure to filter the prefixes of your BGP customers directly on the BG
     And then applied to the upstream BGP session:
 
     ```
+    set policy-options policy-statement MY_OUTPUT_FILTER term CUSTOMER-PREFIXES-V4 from family inet
     set policy-options policy-statement MY_OUTPUT_FILTER term CUSTOMER-PREFIXES-V4 from community CUSTOMER
     set policy-options policy-statement MY_OUTPUT_FILTER term CUSTOMER-PREFIXES-V4 from route-filter 0.0.0.0/0 prefix-length-range /8-/24
     set policy-options policy-statement MY_OUTPUT_FILTER term CUSTOMER-PREFIXES-V4 then accept

--- a/docs/guides/route_filtering/outbound/max_prefix.md
+++ b/docs/guides/route_filtering/outbound/max_prefix.md
@@ -1,6 +1,6 @@
 # Maximum Prefix (Outbound)
 
-This is a quite new feature of some BGP implementations. Here we do not protect our own network, we protect the our neighbors from us accidentally flooding too many IP prefixes towards them.
+This is a quite new feature of some BGP implementations. Here we do not protect our own network, we protect our neighbors from us accidentally flooding too many prefixes towards them.
 
 Of course this also protects our own network, because if our neighbor accepted these prefixes and would send us all the traffic for them, we would drown in packets.
 

--- a/docs/guides/route_filtering/outbound/own_prefix.md
+++ b/docs/guides/route_filtering/outbound/own_prefix.md
@@ -5,7 +5,7 @@
 As a network participating in the global Internet you want to tell other networks about your own prefixes and announce them to the public Internet.
 
 !!! note
-    You peers and upstreams might also apply incoming BGP filters to your BGP sessions and filter your prefixes. Please make sure to create appropriate [RPKI objects](https://www.ripe.net/manage-ips-and-asns/resource-management/rpki/), route/route6 objects and AS sets, for example in the RIPE datebase. It is best practice to also create an AS set although you currebtly only have one ASN, because if your BGP peers build filters based on your AS set you don't need to inform them if you ever announce prefixes with an additional origin ASN.
+    Your peers and upstreams might also apply incoming BGP filters to your BGP sessions and filter your prefixes. Please make sure to create appropriate [RPKI objects](https://www.ripe.net/manage-ips-and-asns/resource-management/rpki/), route/route6 objects and AS sets, for example in the RIPE datebase. It is best practice to also create an AS set although you currently only have one ASN, because if your BGP peers build filters based on your AS set you don't need to inform them if you ever announce prefixes with an additional origin ASN.
 
 ## Configuration
 

--- a/docs/guides/route_filtering/outbound/well_known_communities_traffic_engineering.md
+++ b/docs/guides/route_filtering/outbound/well_known_communities_traffic_engineering.md
@@ -6,7 +6,7 @@ tags:
 # Well-known BGP Communities
 
 So-called well-known communities are defined in RFCs and must be processed by all BGP
-speaking entities.  The [IANA](https://iana.org) keeps a [list](https://www.iana.org/assignments/bgp-well-known-communities/bgp-well-known-communities.xhtml) of well-known communities.
+speaking entities. The [IANA](https://iana.org) keeps a [list](https://www.iana.org/assignments/bgp-well-known-communities/bgp-well-known-communities.xhtml) of well-known communities.
 
 The following well-known communities are quite useful.
 
@@ -23,7 +23,7 @@ similar).
 injecting your prefixes into BGP and leave it off the network blocks which should be
 announced externally.
 
-## NO-AVERTISE
+## NO-ADVERTISE
 
 This well-known community is even stricter then NO-EXPORT. *NO-ADVERTISE* forbids a router
 from announcing a prefix to any BGP neighbor; this also includes iBGP.
@@ -42,7 +42,7 @@ or block all traffic destined to the prefix with this community attached.
 For this to work properly, the receiver should accept longer than usual prefixes (up to /32 in
 IPv4 and up to /128 in IPv6). Also, the receiver should not propagate these prefixes further,
 so either the sender also attaches a NO-EXPORT or the receiver should.
-The purpose, of course, is to fight DOS or DDOS attacks.
+The purpose, of course, is to fight DoS or DDoS attacks.
 
 ## ACCEPT-OWN
 

--- a/docs/working_group/index.md
+++ b/docs/working_group/index.md
@@ -1,3 +1,3 @@
 # DENOG Working Group Routing
 
-Here we want to document our charter, org, communication and other important goals of our group
+Here we want to document our charter, org, communication and other important goals of our group.


### PR DESCRIPTION
- fix typos and remove extra whitespaces
- replace archive.org link with direct link to Citizen Code of Conduct
- standardize spelling of RFC (without space)
- add extra documentation to RFCs from other examples
- standardize spelling of JunOS and add it where not mentioned
- standardize order of RFC1918 prefixes in config snippets
- add reject of 0.0.0.0/0 to JunOS policy statement IPV4-BOGONS (equal to IPv6 PS)
- add IPv6 documentation prefix 3fff::/20 to JunOS policy statement IPV6-BOGONS
- remove 2002:db8::/32 from JunOS policy statement IPV6-BOGONS (this is no documentation prefix)
- remove 2002::/32 from unOS policy statement IPV6-BOGONS (this is not Teredo)
- add "from family inet" to JunOS policy statements (make it more similar to IPv6 PS)
- remove public ASN from Juniper large community example and replace it by example ASN
- remove duplicate "le" in Cisco IOS XR Prefix-Set my-own-network-ipv6