### PR TITLE
Fix emojis not being rendered

### DIFF
--- a/docs/contribution/formatting.md
+++ b/docs/contribution/formatting.md
@@ -34,7 +34,6 @@ We use some [markdown extensions](https://squidfunk.github.io/mkdocs-material/re
 !!! note
     This is a note
 
-
 ```md
 !!! note
     This is a note
@@ -45,7 +44,6 @@ We use some [markdown extensions](https://squidfunk.github.io/mkdocs-material/re
 !!! warning
     This is a warning
 
-
 ```md
 !!! warning
     This is a warning
@@ -53,21 +51,11 @@ We use some [markdown extensions](https://squidfunk.github.io/mkdocs-material/re
 
 ---
 
-### Feature Matrix
-
-|              | RPKI             |
-| ------------ | ---------------- |
-| JunOS        | :material-check: |
-| Cisco IOS-XR | :material-check: |
-| Arista EOS   | :material-close: |
-
----
-
 ### Diagrams
 
 Diagrams use [Mermaid](https://mermaid.js.org/intro/) syntax
 
-``` mermaid
+```mermaid
 graph LR
   OpenConfirm --> OpenConfirm;
   OpenConfirm --> Established;
@@ -86,8 +74,8 @@ graph LR
   Idle --> Idle;
 ```
 
-```
- ``` mermaid
+```md
+ ```mermaid
  graph LR
    A[Start] --> B{Error?};
    B -->|Yes| C[Hmm...];
@@ -95,6 +83,7 @@ graph LR
    D --> B;
    B ---->|No| E[Yay!];
  ```
+
 ```
 
 ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,9 +37,11 @@ theme:
         icon: material/brightness-4
         name: Switch to light mode
 markdown_extensions:
-  #- pymdownx.emoji
-    #emoji_index: !!python/name:material.extensions.emoji.twemoji
-        #emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  # Emojis disabled because certain strings which contain a colon character
+  # (i.e., IPv6 addresses, BGP communities) are interpreted as emojis
+  # - pymdownx.emoji:
+  #     emoji_index: !!python/name:material.extensions.emoji.twemoji
+  #     emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true


### PR DESCRIPTION
Emojis are disabled in the MkDocs config. Simply enabling them fixes the problem.

I guess they were disabled for a reason, but everything seems to be working fine :shrug: 

Main branch output:

<img width="574" height="417" alt="image" src="https://github.com/user-attachments/assets/026c1e38-d465-4971-b142-91666c746962" />

PR branch output:

<img width="694" height="704" alt="image" src="https://github.com/user-attachments/assets/840db141-063f-4eeb-bd40-5e78737e4bc9" />
