### PR TITLE
rpki + tier1 asn: normalize bird2 examples

### DIFF
--- a/docs/guides/route_filtering/inbound/rpki.md
+++ b/docs/guides/route_filtering/inbound/rpki.md
@@ -26,14 +26,16 @@ With RPKI it is possible to validate the origin AS of a BGP announcement. This i
 
     function reject_rpki_invalid4() {
         if roa_check(rpki4, net, bgp_path.last_nonaggregated) = ROA_INVALID then {
-            print "Reject: RPKI invalid: ", net, " ", bgp_path;
+            # optional logging
+            # print "Reject: RPKI invalid: ", net, " ", bgp_path;
             reject;
         }
     }
     
     function reject_rpki_invalid6() {
         if roa_check(rpki6, net, bgp_path.last_nonaggregated) = ROA_INVALID then {
-            print "Reject: RPKI invalid: ", net, " ", bgp_path;
+            # optional logging
+            # print "Reject: RPKI invalid: ", net, " ", bgp_path;
             reject;
         }
     }

--- a/docs/guides/route_filtering/inbound/tier1_asn.md
+++ b/docs/guides/route_filtering/inbound/tier1_asn.md
@@ -33,7 +33,8 @@ Be aware that you need to manually check the prefix list as you could peer with 
     {
       transit_asns = TRANSIT_ASNS;
       if (bgp_path ~ transit_asns) then {
-        print "Reject: Transit ASNs found on IXP Peering: ", net, " ", bgp_path;
+        # optional logging
+        # print "Reject: Transit ASNs found on IXP Peering: ", net, " ", bgp_path;
         reject;
       }
     }


### PR DESCRIPTION
We should normalize the bird2 examples in terms of logging filtered routes