### PR TITLE
[MikroTik] added lots of missing examples, fixed a typo

### DIFF
--- a/docs/guides/route_filtering/inbound/as_path_length.md
+++ b/docs/guides/route_filtering/inbound/as_path_length.md
@@ -1,7 +1,6 @@
 ---
 tags:
   - Huawei VRP missing
-  - Mikrotik missing
   - OpenBGPD missing
   - RtBrick RBFS missing
 ---
@@ -130,6 +129,12 @@ The AS PATH in the DFZ[^1] can become very long. At some point this can become a
           neighbor 2001:db8::1 rcf in example_in()
        address-family ipv4
           neighbor 198.51.100.1 rcf in example_in()
+    ```
+
+=== "MikroTik"
+    ```
+    /routing/filter/rule/
+    add chain=DENOG-IN rule="if ( bgp-path-len > 50 ) { reject }"
     ```
 
 [^1]: Default Free Zone

--- a/docs/guides/route_filtering/inbound/bogon_asn.md
+++ b/docs/guides/route_filtering/inbound/bogon_asn.md
@@ -2,7 +2,6 @@
 tags:
   - Cisco missing
   - Huawei VRP missing
-  - Mikrotik missing
   - OpenBGPD missing
   - RtBrick RBFS missing
 ---
@@ -228,4 +227,21 @@ Bogon AS are autonomous systems which are used for test or demo applications. Th
 
     set policy route-map import-all rule 100 action deny
     set policy route-map import-all rule 100 match as-path bogon-asns
+    ```
+
+=== "MikroTik"
+    ```
+    /routing/filter/num-list
+    add list=BOGON_ASNS range=0 comment="RFC7607"
+    add list=BOGON_ASNS range=23456 comment="RFC4893 AS_TRANS, 2 to 4 byte ASN migrations"
+    add list=BOGON_ASNS range=64496-64511 comment="RFC5398 documentation/example ASNs"
+    add list=BOGON_ASNS range=65536-65551 comment="RFC5398 documentation/example ASNs"
+    add list=BOGON_ASNS range=64512-65534 comment="RFC6996 private ASNs"
+    add list=BOGON_ASNS range=4200000000-4294967294 comment="RFC6996 private ASNs"
+    add list=BOGON_ASNS range=65535 comment="RFC7300 last 16 bit ASN"
+    add list=BOGON_ASNS range=4294967295 comment="RFC7300 last 32 bit ASN"
+    add list=BOGON_ASNS range=65552-131071 comment="IANA reserved ASNs"
+
+    /routing/filter/rule/
+    add chain=DENOG-IN rule="if ( bgp-as-path [[:BOGON_ASNS:]] ) { reject }"    
     ```

--- a/docs/guides/route_filtering/inbound/bogon_prefixes.md
+++ b/docs/guides/route_filtering/inbound/bogon_prefixes.md
@@ -490,3 +490,39 @@ In IPv6, there is a [similar list at IANA](http://www.iana.org/assignments/ipv6-
     set policy prefix-list6 special-purpose-6 rule 21 prefix fe80::/10
     set policy prefix-list6 special-purpose-6 rule 21 le 128
     ```
+
+=== "MikroTik"
+    ```
+    /routing/filter/rule
+    add chain="reject_bogon_prefixes4" rule="if ( afi ipv4 && dst in 0.0.0.0/8 ) { reject }" comment="RFC1122 'this' Network"
+    add chain="reject_bogon_prefixes4" rule="if ( afi ipv4 && dst in 10.0.0.0/8 ) { reject }" comment="RFC1918 Private"
+    add chain="reject_bogon_prefixes4" rule="if ( afi ipv4 && dst in 100.64.0.0/10 ) { reject }" comment="RFC6598 Carrier grade nat space"
+    add chain="reject_bogon_prefixes4" rule="if ( afi ipv4 && dst in 127.0.0.0/8 ) { reject }" comment="RFC1122 Loopback"
+    add chain="reject_bogon_prefixes4" rule="if ( afi ipv4 && dst in 169.254.0.0/16 ) { reject }" comment="RFC3927 Link Local"
+    add chain="reject_bogon_prefixes4" rule="if ( afi ipv4 && dst in 172.16.0.0/12 ) { reject }" comment="RFC1918 Private"
+    add chain="reject_bogon_prefixes4" rule="if ( afi ipv4 && dst in 192.0.2.0/24 ) { reject }" comment="RFC5737 Documentation TEST-NET-1"
+    add chain="reject_bogon_prefixes4" rule="if ( afi ipv4 && dst in 192.168.0.0/16 ) { reject }" comment="RFC1918 Private"
+    add chain="reject_bogon_prefixes4" rule="if ( afi ipv4 && dst in 198.18.0.0/15 ) { reject }" comment="RFC2544 Benchmarking"
+    add chain="reject_bogon_prefixes4" rule="if ( afi ipv4 && dst in 198.51.100.0/24 ) { reject }" comment="RFC5737 Documentation TEST-NET-2"
+    add chain="reject_bogon_prefixes4" rule="if ( afi ipv4 && dst in 203.0.113.0/24 ) { reject }" comment="RFC5737 Documentation TEST-NET-3"
+    add chain="reject_bogon_prefixes4" rule="if ( afi ipv4 && dst in 224.0.0.0/4 ) { reject }" comment="RFC5771 Multicast"
+    add chain="reject_bogon_prefixes4" rule="if ( afi ipv4 && dst in 240.0.0.0/4 ) { reject }" comment="RFC1112 Reserved"
+    add chain="reject_bogon_prefixes4" rule=return comment="JUMP back to parent"
+
+    add chain="reject_bogon_prefixes6" rule="if ( afi ipv6 && dst in ::/8 ) { reject }" comment="RFC4291 Loopback and more"
+    add chain="reject_bogon_prefixes6" rule="if ( afi ipv6 && dst in 0100::/64 ) { reject }" comment="RFC6666 Discard-Only Address Block"
+    add chain="reject_bogon_prefixes6" rule="if ( afi ipv6 && dst in 2001:2::/48 ) { reject }" comment="RFC5180 Benchmarking"
+    add chain="reject_bogon_prefixes6" rule="if ( afi ipv6 && dst in 2001:10::/28 ) { reject }" comment="RFC4843 ORCHID"
+    add chain="reject_bogon_prefixes6" rule="if ( afi ipv6 && dst in 2001:db8::/32 ) { reject }" comment="RFC7450 Documentation"
+    add chain="reject_bogon_prefixes6" rule="if ( afi ipv6 && dst in 3ffe::/16 ) { reject }" comment="RFC3701 old 6bone"
+    add chain="reject_bogon_prefixes6" rule="if ( afi ipv6 && dst in 3fff::/20 ) { reject }" comment="RFC9637 Documentation"
+    add chain="reject_bogon_prefixes6" rule="if ( afi ipv6 && dst in 5f00::/16 ) { reject }" comment="RFC9602 SRv6 SIDs"
+    add chain="reject_bogon_prefixes6" rule="if ( afi ipv6 && dst in fc00::/7 ) { reject }" comment="RFC4193,RFC8190 Unique-Local"
+    add chain="reject_bogon_prefixes6" rule="if ( afi ipv6 && dst in fe80::/10 ) { reject }" comment="RFC4291 Link-Local Unicast"
+    add chain="reject_bogon_prefixes6" rule="if ( afi ipv6 && dst in fec0::/10 ) { reject }" comment="RFC3879 old Site-Local Unicast"
+    add chain="reject_bogon_prefixes6" rule="if ( afi ipv6 && dst in ff00::/8 ) { reject }" comment="RFC4291 Multicast"
+    add chain="reject_bogon_prefixes6" rule=return comment="JUMP back to parent"
+
+    add chain=DENOG-IN rule="if ( afi ipv4) { jump reject_bogon_prefixes4 }"
+    add chain=DENOG-IN rule="if ( afi ipv6) { jump reject_bogon_prefixes6 }"
+    ```

--- a/docs/guides/route_filtering/inbound/default_route.md
+++ b/docs/guides/route_filtering/inbound/default_route.md
@@ -2,7 +2,6 @@
 tags:
   - Arista missing
   - Huawei VRP missing
-  - Mikrotik missing
   - Nokia SR OS missing
   - OpenBGPD missing
   - RtBrick RBFS missing
@@ -156,4 +155,11 @@ On the other hand, if you want the full routing table, you should not accept any
     set policy route-map prefixes-in rule 10 action deny
     set policy route-map prefixes-in rule 10 match ip address prefix-list default-route-v4
     set policy route-map prefixes-in rule 10 match ipv6 address prefix-list default-route-v6
+    ```
+
+=== "MikroTik"
+    ```
+    /routing/filter/rule/
+    add chain=DENOG-IN rule="if ( afi ipv4 && dst == 0.0.0.0/0 ) { reject }"
+    add chain=DENOG-IN rule="if ( afi ipv6 && dst == ::/0 ) { reject }"
     ```

--- a/docs/guides/route_filtering/inbound/max_prefix.md
+++ b/docs/guides/route_filtering/inbound/max_prefix.md
@@ -48,11 +48,24 @@ Configuration examples:
     ```
 
 === "Mikrotik"
-    This shuts down your session when 1000 prefixes are received and restarts it after one hour:
+    For RouterOS v6 this shuts down your session when 1000 prefixes are received and restarts it after one hour:
     ```
     add name=AS64496 remote-as=64496 \
-        remote-address=198.51.100.1 max-prefix-limig=1000 max-prefix-restart-time=1h
+        remote-address=198.51.100.1 max-prefix-limit=1000 max-prefix-restart-time=1h
     ```
+
+    On RouterOS v7 something like  this should do:
+    ```
+    /routing/bgp/connection
+    add instance=bgp-instance-1 name=HE local.role=ebgp \
+        afi=ip input.limit-process-routes-ipv4=1000 remote.address=185.1.167.69 .as=6939
+    add instance=bgp-instance-1 name=HE local.role=ebgp \
+        afi=ipv6 input.limit-process-routes-ipv6=1000 remote.address=2001:7f8:f2:e1::6939:1 .as=6939
+    ```
+    The documentation however is a bit vague:
+    "Try to limit the amount of received IPv4 routes to the specified number.
+    This number does not represent the exact number of routes going to be installed in the routing table by the peer.
+    BGP session "clear" command must be used to reset the flag if the limit is reached."
 
 === "BIRD 2/3"
     ```

--- a/docs/guides/route_filtering/inbound/max_prefix.md
+++ b/docs/guides/route_filtering/inbound/max_prefix.md
@@ -54,7 +54,7 @@ Configuration examples:
         remote-address=198.51.100.1 max-prefix-limit=1000 max-prefix-restart-time=1h
     ```
 
-    On RouterOS v7 something like  this should do:
+    On RouterOS v7 something like this should do:
     ```
     /routing/bgp/connection
     add instance=bgp-instance-1 name=HE local.role=ebgp \
@@ -63,9 +63,10 @@ Configuration examples:
         afi=ipv6 input.limit-process-routes-ipv6=1000 remote.address=2001:7f8:f2:e1::6939:1 .as=6939
     ```
     The documentation however is a bit vague:
-    "Try to limit the amount of received IPv4 routes to the specified number.
-    This number does not represent the exact number of routes going to be installed in the routing table by the peer.
-    BGP session "clear" command must be used to reset the flag if the limit is reached."
+    
+    > Try to limit the amount of received IPv4 routes to the specified number.
+    > This number does not represent the exact number of routes going to be installed in the routing table by the peer.
+    > BGP session "clear" command must be used to reset the flag if the limit is reached.
 
 === "BIRD 2/3"
     ```

--- a/docs/guides/route_filtering/inbound/own_prefix.md
+++ b/docs/guides/route_filtering/inbound/own_prefix.md
@@ -4,7 +4,6 @@ tags:
   - BIRD missing
   - Cisco missing
   - Huawei VRP missing
-  - Mikrotik missing
   - Nokia SR OS missing
   - OpenBGPD missing
   - RtBrick RBFS missing
@@ -107,4 +106,14 @@ Your own networks should be stored in lists and then used in policy for external
     set policy route-map import rule 10 action deny
     set policy route-map import rule 10 match ip address prefix-list own
     set policy route-map import rule 10 match ipv6 address prefix-list own-6
+    ```
+
+=== "MikroTik"
+    ```
+    /routing/filter/rule
+    add chain=reject_own_prefixes rule="if ( afi ipv4 && dst in <PLEASE INSERT YOUR PREFIX HERE> ) { reject }"
+    add chain=reject_own_prefixes rule="if ( afi ipv6 && dst in <PLEASE INSERT YOUR PREFIX HERE> ) { reject }"
+    add chain=reject_own_prefixes rule=return comment="JUMP back to parent rule"
+
+    add chain=DENOG-IN rule="jump reject_own_prefixes"
     ```

--- a/docs/guides/route_filtering/inbound/peering_lan.md
+++ b/docs/guides/route_filtering/inbound/peering_lan.md
@@ -168,4 +168,16 @@ and convert it to your router configuration.
     set policy route-map prefixes-in rule 10 match ipv6 address prefix-list ipv6-ixplans
     ```
 
+=== "MikroTik""
+    ```
+    /ip/firewall/address-list
+    add list=ixp_prefixes4 address=185.1.155.0/24 comment="LocIX DUS"
+    /ipv6/firewall/address-list
+    add list=ixp_prefixes6 address=2a0c:b641:701::/64 comment="LocIX DUS"
+
+    /routing/filter/rule
+    add chain=DENOG-IN rule="if ( afi ipv4 && dst in ixp_prefixes4 ) { reject }"
+    add chain=DENOG-IN rule="if ( afi ipv6 && dst in ixp_prefixes6 ) { reject }"
+    ```
+
 [^1]: Internet eXchange Point

--- a/docs/guides/route_filtering/inbound/prefix_length.md
+++ b/docs/guides/route_filtering/inbound/prefix_length.md
@@ -81,13 +81,28 @@ Configuration examples:
     ```
 
 === "Mikrotik"
-    Mikrotik works with filter-lists, for easier readability you can use sub-filters (note this example only shows the filter lists itself):
+    Mikrotik RouterOS v6 works with filter-lists, for easier readability you can use sub-filters (note this example only shows the filter lists itself):
     ```
     /routing filter
     add action=jump chain=upstream-in-v4 jump-target=ipv4-size
     ...
     add action=reject chain=ipv4-size prefix-length=0-7
     add action=reject chain=ipv4-size prefix-length=25-32
+    ```
+
+    For RouterOS v7 you could do it this way:
+    ```
+    /routing/filter/rule
+    add chain=bgp_reject_too_specific rule="if ( afi ipv4 && dst-len > 24 ) { reject }"
+    add chain=bgp_reject_too_specific rule="if ( afi ipv6 && dst-len > 48 ) { reject }"
+    add chain=bgp_reject_too_specific rule=return comment="JUMP back to parent rule"
+
+    add chain=bgp_reject_too_large rule="if ( afi ipv4 && dst-len < 8 ) { reject }"
+    add chain=bgp_reject_too_large rule="if ( afi ipv6 && dst-len < 16 ) { reject }"
+    add chain=bgp_reject_too_large rule=return comment="JUMP back to parent rule"
+
+    add chain=DENOG-IN rule="jump bgp_reject_too_specific"
+    add chain=DENOG-IN rule="jump bgp_reject_too_large"
     ```
 
 === "BIRD 2/3"

--- a/docs/guides/route_filtering/inbound/rpki.md
+++ b/docs/guides/route_filtering/inbound/rpki.md
@@ -5,7 +5,6 @@ tags:
   - Cisco IOS XR missing
   - Huawei VRP missing
   - Junos missing
-  - Mikrotik missing
   - Nokia SR OS missing
   - OpenBGPD missing
   - VyOS missing
@@ -120,4 +119,17 @@ With RPKI it is possible to validate the origin AS of a BGP announcement. This i
     route-map rpki permit 30
       match rpki valid
       set local-preference 200
+    ```
+
+=== "MikroTik"
+    ```
+    /routing rpki
+    add address=10.23.23.23 comment="rpki1.example.com" group=VALIDATORS port=3323 refresh-interval=20
+    add address=2001:db8::42 comment="rpki2.example.com" group=VALIDATORS port=3323 refresh-interval=20
+
+    /routing/filter/rule
+    add chain=check_rpki rule="rpki-verify VALIDATORS"
+    add chain=check_rpki rule="if (rpki invalid) { reject } else { return }"
+
+    add chain=DENOG-IN rule="jump check_rpki"
     ```

--- a/docs/guides/route_filtering/inbound/tier1_asn.md
+++ b/docs/guides/route_filtering/inbound/tier1_asn.md
@@ -6,7 +6,6 @@ tags:
   - FRR missing
   - Huawei VRP missing
   - Junos missing
-  - Mikrotik missing
   - Nokia SR OS missing
   - OpenBGPD missing
   - VyOS missing
@@ -70,4 +69,31 @@ Be aware that you need to manually check the prefix list as you could peer with 
         };
       }
     }
+    ```
+
+=== "MikroTik"
+    Source: [NLNOG](https://bgpfilterguide.nlnog.net/guides/no_transit_leaks/#routeros-v7)
+    ```
+    /routing/filter/num-list
+    add list=TRANSIT_ASNS range=174 comment="Cogent" 
+    add list=TRANSIT_ASNS range=701 comment="UUNET" 
+    add list=TRANSIT_ASNS range=1299 comment="Telia" 
+    add list=TRANSIT_ASNS range=2914 comment="NTT Ltd." 
+    add list=TRANSIT_ASNS range=3257 comment="GTT Backbone" 
+    add list=TRANSIT_ASNS range=3320 comment="Deutsche Telekom AG (DTAG)" 
+    add list=TRANSIT_ASNS range=3356 comment="Level3" 
+    add list=TRANSIT_ASNS range=3491 comment="PCCW" 
+    add list=TRANSIT_ASNS range=4134 comment="Chinanet" 
+    add list=TRANSIT_ASNS range=5511 comment="Orange opentransit" 
+    add list=TRANSIT_ASNS range=6453 comment="Tata Communications" 
+    add list=TRANSIT_ASNS range=6461 comment="Zayo Bandwidth" 
+    add list=TRANSIT_ASNS range=6762 comment="Seabone / Telecom Italia" 
+    add list=TRANSIT_ASNS range=6830 comment="Liberty Global"
+    add list=TRANSIT_ASNS range=7018 comment="AT&T"  
+    
+    /routing/filter/rule
+    add chain=reject_transit rule="if (bgp-as-path [[:TRANSIT_ASNS:]]){ reject }"
+
+    add chain=CUSTOMER-IN rule="jump reject_transit"
+    add chain=PEERING-OUT rule="jump reject_transit"
     ```

--- a/docs/guides/route_filtering/outbound/max_prefix.md
+++ b/docs/guides/route_filtering/outbound/max_prefix.md
@@ -36,3 +36,6 @@ Configuration examples:
     ```
     set protocols bgp neighbor 198.51.100.1 address-family ipv4-unicast maximum-prefix-out 1000
     ```
+
+=== "MikroTik"
+    Doesn't seem possible as of 2026-03-19


### PR DESCRIPTION
Added some of the missing examples.

I ran `ec` and verified my changes with `mkdocs serve` -- I had to (locally) fix the `mkdocs.yml` to get the latter running though:

```
--- mkdocs.yml	2026-03-18 22:24:44
+++ mkdocs.yml.my	2026-03-18 22:24:38
@@ -42,20 +42,17 @@
   # - pymdownx.emoji:
   #     emoji_index: !!python/name:material.extensions.emoji.twemoji
   #     emoji_generator: !!python/name:material.extensions.emoji.to_svg
-  - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true
   - admonition
   - pymdownx.details
   - attr_list
   - footnotes
-  - attr_list
   - md_in_html
   - pymdownx.superfences:
       custom_fences:
         - name: mermaid
           class: mermaid
-          format: !!python/name:pymdownx.superfences.fence_code_format
 plugins:
   - git-revision-date-localized:
       enable_parallel_processing: false
```

